### PR TITLE
Add Imagi-World tutorial modal with sandbox practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -184,6 +184,12 @@
             transform: none;
         }
 
+        #btnInstructions.completed::after {
+            content: ' ✓';
+            font-weight: 700;
+            color: #2ecc71;
+        }
+
         button.secondary {
             background: #0f3460;
         }
@@ -405,10 +411,233 @@
                 flex-direction: column;
             }
         }
+
+        #dlgInstructions {
+            position: fixed;
+            inset: 0;
+            background: rgba(10, 14, 26, 0.88);
+            backdrop-filter: blur(6px);
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            padding: 40px 20px;
+            z-index: 999;
+        }
+
+        #dlgInstructions[hidden] {
+            display: none;
+        }
+
+        #dlgInstructions > header,
+        #dlgInstructions > footer,
+        #dlgInstructions > nav,
+        #dlgInstructions > article {
+            width: min(960px, 100%);
+        }
+
+        #dlgInstructions > header {
+            background: #16213e;
+            padding: 20px 60px 20px 24px;
+            border-radius: 12px 12px 0 0;
+            position: relative;
+        }
+
+        #instTitle {
+            margin-bottom: 12px;
+            font-size: 1.6rem;
+        }
+
+        #instClose {
+            position: absolute;
+            top: 16px;
+            right: 16px;
+            background: transparent;
+            border: none;
+            font-size: 1.4rem;
+            line-height: 1;
+            color: #e94560;
+            cursor: pointer;
+            padding: 4px 8px;
+        }
+
+        #instClose:hover {
+            transform: none;
+            color: #fff;
+            background: transparent;
+            box-shadow: none;
+        }
+
+        #instTabs {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 8px;
+            background: #0f3460;
+            padding: 16px;
+        }
+
+        #instTabs button {
+            background: #16213e;
+            border-radius: 6px;
+            padding: 10px;
+            font-size: 0.95rem;
+            border: 1px solid transparent;
+        }
+
+        #instTabs button.active {
+            background: #e94560;
+            border-color: #f08fa2;
+        }
+
+        #instTabs button.visited:not(.active) {
+            border-color: #27ae60;
+        }
+
+        #instContent {
+            background: #0a0e1a;
+            padding: 24px;
+            min-height: 280px;
+            max-height: 360px;
+            overflow-y: auto;
+            outline: none;
+        }
+
+        #instContent h3 {
+            margin-bottom: 12px;
+            font-size: 1.3rem;
+        }
+
+        #instContent p {
+            margin-bottom: 12px;
+            line-height: 1.6;
+        }
+
+        #instContent ul,
+        #instContent ol {
+            margin-left: 20px;
+            margin-bottom: 12px;
+            line-height: 1.6;
+        }
+
+        #instFooter {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            background: #16213e;
+            padding: 16px 24px;
+            border-radius: 0 0 12px 12px;
+        }
+
+        #instFooter .inline {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            font-size: 0.95rem;
+        }
+
+        #instFooter .spacer {
+            flex: 1;
+        }
+
+        .inst-brand-tagline {
+            font-size: 0.9rem;
+            color: #f5c0d1;
+            line-height: 1.5;
+        }
+
+        body.dialog-open {
+            overflow: hidden;
+        }
+
+        .sandbox-panel {
+            margin-top: 16px;
+            padding: 16px;
+            background: #111a33;
+            border-radius: 8px;
+        }
+
+        .sandbox-panel h4 {
+            margin-bottom: 8px;
+            font-size: 1.1rem;
+        }
+
+        .sandbox-controls {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 10px;
+            margin-bottom: 12px;
+        }
+
+        .sandbox-letter-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+            gap: 10px;
+            margin-bottom: 12px;
+        }
+
+        .sandbox-letter {
+            background: #16213e;
+            padding: 10px;
+            border-radius: 6px;
+        }
+
+        .sandbox-letter label {
+            font-size: 0.85rem;
+            margin-bottom: 6px;
+        }
+
+        .sandbox-letter input[type="text"] {
+            width: 100%;
+            padding: 8px;
+            border-radius: 4px;
+            border: 1px solid #1a4d7a;
+            background: #0f3460;
+            color: #fff;
+        }
+
+        .sandbox-atom-list {
+            margin-bottom: 12px;
+            font-family: 'Courier New', monospace;
+        }
+
+        .sandbox-journal {
+            margin-top: 12px;
+            max-height: 140px;
+            overflow-y: auto;
+            background: #0f0f24;
+            padding: 10px;
+            border-radius: 6px;
+            font-size: 0.85rem;
+        }
+
+        .sandbox-journal-entry {
+            margin-bottom: 8px;
+            padding-bottom: 8px;
+            border-bottom: 1px dashed rgba(233, 69, 96, 0.4);
+        }
+
+        @media (max-width: 780px) {
+            #instTabs {
+                grid-template-columns: repeat(2, 1fr);
+            }
+
+            #instFooter {
+                flex-direction: column;
+                align-items: stretch;
+            }
+
+            #instFooter .spacer {
+                display: none;
+            }
+
+            .inst-footer-brand {
+                max-width: 100%;
+            }
+        }
     </style>
 </head>
 <body>
-    <div class="container">
+    <main class="container">
         <h1>🌀Imagi-world🌀</h1>
 
         <div class="controls">
@@ -464,6 +693,7 @@
                     <button id="stop-btn" class="danger" disabled>Stop</button>
                     <button id="repeat-btn" class="secondary" disabled>Repeat Audio</button>
                     <button id="preview-btn" class="secondary">Voice Preview</button>
+                    <button id="btnInstructions" aria-haspopup="dialog" aria-controls="dlgInstructions">Instructions</button>
                 </div>
                 <div class="button-group">
                     <button id="test-btn" class="secondary">Run Tests</button>
@@ -522,7 +752,38 @@
             <h3>Test Results</h3>
             <div id="test-results"></div>
         </div>
-    </div>
+    </main>
+
+    <section id="dlgInstructions" role="dialog" aria-modal="true" aria-labelledby="instTitle" hidden>
+        <header>
+            <h2 id="instTitle">Imagi-World: Learn the Arc of Abstraction</h2>
+            <p class="inst-brand-tagline"><strong>Imagi-World</strong> trains maximized imagination across the <strong>Arc of Abstraction</strong>. At its intersection with your lived experience lies the engine of creation, recognition, and extension of thought—your route to deeper consciousness.</p>
+            <button id="instClose" aria-label="Close">✕</button>
+        </header>
+
+        <nav id="instTabs" aria-label="Tutorial Sections">
+            <button data-tab="welcome" class="active">Welcome</button>
+            <button data-tab="compass">Imagi-Compass</button>
+            <button data-tab="anchor">Anchor &amp; Transform</button>
+            <button data-tab="examples">Guided Examples</button>
+            <button data-tab="practice">Sandbox Practice</button>
+            <button data-tab="mastery">Mastery Path</button>
+            <button data-tab="pitfalls">Pitfalls &amp; FAQ</button>
+            <button data-tab="glossary">Glossary</button>
+        </nav>
+
+        <article id="instContent" tabindex="0" aria-live="polite"></article>
+
+        <footer id="instFooter">
+            <label class="inline">
+                <input id="instReadAloud" type="checkbox" />
+                Read this section aloud
+            </label>
+            <div class="spacer"></div>
+            <button id="instPrev">← Previous</button>
+            <button id="instNext">Next →</button>
+        </footer>
+    </section>
 
     <script type="module">
         const RELATION_WORDS = { N: 'north of', S: 'south of', E: 'east of', W: 'west of' };
@@ -549,6 +810,153 @@
         const numTrialsInput = document.getElementById('numTrialsInput');
         const numTrialsSlider = document.getElementById('numTrialsSlider');
         const numTrialsDisplay = document.getElementById('numTrialsDisplay');
+
+        const TUTORIAL_SECTIONS = [
+            {
+                id: 'welcome',
+                title: 'Welcome to Imagi-World',
+                html: `
+                    <h3>Welcome to Imagi-World</h3>
+                    <p><strong>Imagi-World</strong> trains maximized imagination across the <strong>Arc of Abstraction</strong>. At its intersection with your lived experience lies the engine of creation, recognition, and extension of thought—your route to deeper consciousness.</p>
+                    <p>Imagi-World is imagination with a steering wheel. You will learn to project your lived thoughts onto letters and then move them along the <strong>Arc of Abstraction</strong> using the <strong>Imagi-Compass</strong>. North means <strong>up-shift</strong> to higher-order concepts, South means <strong>down-shift</strong> to concrete instances, East means <strong>analogue</strong> (same role/sibling concept), West means <strong>opposite</strong> (counterpart/foil).</p>
+                    <p>The spatial logic remains strict; your analogies ride on top. This union—formal clarity plus creative projection—is our brand and our method.</p>
+                    <p><strong>Outcome:</strong> by the end, you will anchor any symbol to a vivid mental seed and transform it consistently through multiple relational steps, even under time pressure.</p>
+                `,
+                speech: 'Welcome to Imagi-World. Imagi-World trains maximized imagination across the Arc of Abstraction. At its intersection with your lived experience lies the engine of creation, recognition, and extension of thought—your route to deeper consciousness. Imagi-World is imagination with a steering wheel. You will learn to project your lived thoughts onto letters and then move them along the Arc of Abstraction using the Imagi-Compass. North means up-shift to higher-order concepts. South means down-shift to concrete instances. East means analogue, the same role or a sibling concept. West means opposite, the counterpart or foil. The spatial logic remains strict, and your analogies ride on top. This union, formal clarity plus creative projection, is our brand and our method. Outcome: by the end, you will anchor any symbol to a vivid mental seed and transform it consistently through multiple relational steps, even under time pressure.'
+            },
+            {
+                id: 'compass',
+                title: 'The Imagi-Compass',
+                html: `
+                    <h3>The Imagi-Compass</h3>
+                    <ul>
+                        <li><strong>North (↑ Up-shift):</strong> move to meta, greater scale, more general, more intense. “Candle → Fireworks”; “Task → Project → Program.”</li>
+                        <li><strong>South (↓ Down-shift):</strong> move to instance, component, concrete, less intense. “Theory → Example”; “System → Tool → Part.”</li>
+                        <li><strong>East (→ Analogue):</strong> parallel function or sibling concept. “Candle → Lantern”; “Fact → Case study”; “Parent → Guardian.”</li>
+                        <li><strong>West (← Opposite):</strong> antonym/counter-role. “Fact ↔ Fiction”; “Order ↔ Chaos”; “Light ↔ Darkness.”</li>
+                    </ul>
+                    <p><strong>Rule:</strong> your analogical mapping must be <strong>self-consistent</strong> within a session. Reframes are allowed but must be acknowledged.</p>
+                `,
+                speech: 'The Imagi-Compass. North, the up-shift, moves to meta, to greater scale, to more general or more intense territory. Candle to fireworks. Task to project to program. South, the down-shift, moves to instance, to component, to concrete or less intense forms. Theory to example. System to tool to part. East, the analogue, is the parallel function or sibling concept. Candle to lantern. Fact to case study. Parent to guardian. West, the opposite, is the antonym or counter-role. Fact to fiction. Order to chaos. Light to darkness. Rule: your analogical mapping must be self-consistent within a session. Reframes are allowed but must be acknowledged.'
+            },
+            {
+                id: 'anchor',
+                title: 'Step-by-Step: Anchor & Transform',
+                html: `
+                    <h3>Step-by-Step: Anchor &amp; Transform</h3>
+                    <ol>
+                        <li><strong>Anchor</strong> one letter from the current premise to a real concept from your stream of consciousness (write it or think it). Example: <code>X := “Fact”</code>.</li>
+                        <li><strong>Transform</strong> per atom:
+                            <ul>
+                                <li><code>Y is north of X</code> → <code>Y := Up-shift(X)</code> → “Theory”.</li>
+                                <li><code>Z is west of X</code> → <code>Z := Opposite(X)</code> → “Fiction”.</li>
+                                <li><code>R is south of Y</code> → <code>R := Down-shift(Y)</code> → “Example”.</li>
+                                <li><code>H is east of R</code> → <code>H := Analogue(R)</code> → “Case study”.</li>
+                            </ul>
+                        </li>
+                        <li><strong>Check coherence</strong>: does each transformed concept match its relational cue? If yes, commit this mapping to your session notes.</li>
+                        <li><strong>Never bleed analogies into scoring</strong>: logic is graded by the formal engine; analogies are your training mirror.</li>
+                    </ol>
+                    <p><strong>Mantra:</strong> <strong>Anchor → Transform → Cohere → Commit.</strong></p>
+                `,
+                speech: 'Step-by-Step: Anchor and Transform. One: Anchor one letter from the current premise to a real concept from your stream of consciousness, write it or think it. Example: X equals Fact. Two: Transform per atom. Y is north of X, so Y equals the up-shift of X, Theory. Z is west of X, so Z equals the opposite of X, Fiction. R is south of Y, so R equals the down-shift of Y, Example. H is east of R, so H equals the analogue of R, Case study. Three: Check coherence. Does each transformed concept match its relational cue? If yes, commit this mapping to your session notes. Four: Never bleed analogies into scoring. Logic is graded by the formal engine; analogies are your training mirror. Mantra: Anchor, Transform, Cohere, Commit.'
+            },
+            {
+                id: 'examples',
+                title: 'Guided Examples',
+                html: `
+                    <h3>Guided Examples</h3>
+                    <p><strong>Example A (single atom):</strong><br>Premise: “N is north of J.”<br>Anchor <code>J := Candle</code>. Up-shift → <code>N := Fireworks</code>. Coherence: higher intensity → ✓.</p>
+                    <p><strong>Example B (two atoms, same head):</strong><br>Premise: “Z is south of J; Z is west of P.”<br>Anchor <code>J := Theory</code>, <code>P := Order</code>. Then: <code>Z := Example</code> (down from Theory) and also <code>Z := Chaos</code> (opposite of Order). If a single symbol must satisfy both, reconcile by <strong>compound mapping</strong>: <code>Z := “Chaotic example”</code>. Log the compound so you can revisit it.</p>
+                    <p><strong>Example C (four atoms, your earlier case):</strong><br>“H is east of R; Y is north of X; R is south of Y; Z is west of X.”<br>A consistent set: <code>X := Fact</code>, <code>Y := Theory</code>, <code>R := Example</code>, <code>H := Case study</code>, <code>Z := Fiction</code>.<br>Practice until this becomes fluid and fast.</p>
+                `,
+                speech: 'Guided Examples. Example A, single atom. Premise: N is north of J. Anchor J as Candle. Up-shift to set N as Fireworks. Coherence: higher intensity, confirmed. Example B, two atoms with the same head. Premise: Z is south of J; Z is west of P. Anchor J as Theory and P as Order. Then Z equals Example, down from Theory, and also Z equals Chaos, opposite of Order. When a single symbol must satisfy both, reconcile by compound mapping: Z equals Chaotic example. Log the compound so you can revisit it. Example C, four atoms, your earlier case. H is east of R; Y is north of X; R is south of Y; Z is west of X. A consistent set: X equals Fact, Y equals Theory, R equals Example, H equals Case study, Z equals Fiction. Practice until this becomes fluid and fast.'
+            },
+            {
+                id: 'practice',
+                title: 'Sandbox Practice (Not Scored)',
+                html: `
+                    <h3>Sandbox Practice (Not Scored)</h3>
+                    <ul>
+                        <li>This is a safe studio. Load the <strong>latest premise</strong> (button “Load current premise”), or spawn a <strong>fresh training premise</strong> (button “Spawn practice premise”).</li>
+                        <li>Enter concepts for the letters; click <strong>Apply Relation Operations</strong> to auto-suggest analogues/opposites/up/down (you may override).</li>
+                        <li>Use <strong>Commit to Journal</strong> to save your mapping snapshots (they do not affect your game score).</li>
+                        <li>Toggle <strong>Read this section aloud</strong> for gentle narration using the same single voice the game uses.</li>
+                    </ul>
+                    <p><strong>Tip:</strong> strive for <strong>one-sentence explanations</strong> that justify your choices: “I chose <em>Theory</em> above <em>Fact</em> because it generalizes observations into predictive structure.”</p>
+                `,
+                speech: 'Sandbox Practice, not scored. This is a safe studio. Load the latest premise with the button Load current premise, or spawn a fresh training premise with the button Spawn practice premise. Enter concepts for the letters; click Apply Relation Operations to auto-suggest analogues, opposites, up, or down shifts. You may override anything. Use Commit to Journal to save your mapping snapshots. They do not affect your game score. Toggle Read this section aloud for gentle narration using the same single voice the game uses. Tip: strive for one-sentence explanations that justify your choices, such as, I chose Theory above Fact because it generalizes observations into predictive structure.'
+            },
+            {
+                id: 'mastery',
+                title: 'Mastery: From Symbols to Schemas',
+                html: `
+                    <h3>Mastery: From Symbols to Schemas</h3>
+                    <ul>
+                        <li><strong>Level 1 — Single-atom fluency:</strong> 95% accuracy in naming valid up/down/analogue/opposite for any anchor within 3 seconds.</li>
+                        <li><strong>Level 2 — Two-atom coordination:</strong> keep consistency when a letter appears in two relations; reconcile tensions by compound mappings (“chaotic example”).</li>
+                        <li><strong>Level 3 — Chain reasoning:</strong> three or more atoms spanning two axes; maintain semantic integrity across the chain.</li>
+                        <li><strong>Level 4 — Near-miss foils:</strong> detect when premises <strong>look</strong> similar but fail one criterion (anchoring parity, mapping, axis alignment, derivability). Explain <strong>why</strong> they’re not matches in plain language.</li>
+                        <li><strong>Level 5 — Transfer:</strong> take a mapping that worked in one theme (“Learning &amp; Illumination”) and remake it in a different theme (“Teams &amp; Leadership”), preserving relational roles: <code>Fact→Novice Task</code>, <code>Theory→Best Practice</code>, <code>Example→Case Review</code>, <code>Case study→Playbook</code>, <code>Fiction→Myth/Misconception</code>.</li>
+                    </ul>
+                    <p><strong>Mastery litmus:</strong> you can improvise <strong>new, coherent mappings</strong> at speed, across themes, while the logic engine remains satisfied—no contradictions, no shortcuts.</p>
+                `,
+                speech: 'Mastery: From Symbols to Schemas. Level one, single-atom fluency: ninety-five percent accuracy in naming valid up, down, analogue, or opposite moves for any anchor within three seconds. Level two, two-atom coordination: keep consistency when a letter appears in two relations; reconcile tensions by compound mappings such as Chaotic example. Level three, chain reasoning: three or more atoms spanning two axes; maintain semantic integrity across the chain. Level four, near-miss foils: detect when premises look similar but fail one criterion—anchoring parity, mapping, axis alignment, derivability. Explain why they are not matches in plain language. Level five, transfer: take a mapping that worked in one theme, Learning and Illumination, and remake it in a different theme, Teams and Leadership, preserving relational roles: Fact to Novice Task, Theory to Best Practice, Example to Case Review, Case study to Playbook, Fiction to Myth or Misconception. Mastery litmus: you can improvise new, coherent mappings at speed, across themes, while the logic engine remains satisfied—no contradictions, no shortcuts.'
+            },
+            {
+                id: 'pitfalls',
+                title: 'Pitfalls & FAQ',
+                html: `
+                    <h3>Pitfalls &amp; FAQ</h3>
+                    <dl>
+                        <dt><strong>Q:</strong> Can I use the same word for East (analogue)?</dt>
+                        <dd><strong>A:</strong> Prefer <strong>siblings</strong>, not duplicates. “Candle → Lantern,” not “Candle → Candle.”</dd>
+                        <dt><strong>Q:</strong> My West choice feels too cartoonish.</dt>
+                        <dd><strong>A:</strong> “Opposite” includes <strong>counter-role</strong> or <strong>antagonist</strong>, not just antonym. “Order ↔ Chaos,” “Plan ↔ Improvisation.”</dd>
+                        <dt><strong>Q:</strong> What if my mapping breaks later?</dt>
+                        <dd><strong>A:</strong> Use a <strong>Reframe</strong> action. Log it. Consistency matters more than stubbornness.</dd>
+                        <dt><strong>Q:</strong> Do analogies change scoring?</dt>
+                        <dd><strong>A:</strong> No. Scoring is formal. Analogies train your <strong>semantic agility</strong>.</dd>
+                    </dl>
+                `,
+                speech: 'Pitfalls and FAQ. Question: Can I use the same word for East, the analogue? Answer: Prefer siblings, not duplicates. Candle to Lantern, not Candle to Candle. Question: My West choice feels too cartoonish. Answer: Opposite includes counter-role or antagonist, not just antonym. Order to Chaos. Plan to Improvisation. Question: What if my mapping breaks later? Answer: Use a Reframe action. Log it. Consistency matters more than stubbornness. Question: Do analogies change scoring? Answer: No. Scoring is formal. Analogies train your semantic agility.'
+            },
+            {
+                id: 'glossary',
+                title: 'Glossary',
+                html: `
+                    <h3>Glossary</h3>
+                    <ul>
+                        <li><strong>Arc of Abstraction:</strong> the mental continuum from concrete/particular to abstract/general.</li>
+                        <li><strong>Up-shift / Down-shift:</strong> moves along the Arc (North/South).</li>
+                        <li><strong>Analogue / Opposite:</strong> lateral moves preserving or inverting role (East/West).</li>
+                        <li><strong>Anchor:</strong> your chosen seed concept for a letter.</li>
+                        <li><strong>Compound mapping:</strong> a single letter carrying a composed phrase to satisfy multiple relations (e.g., “chaotic example”).</li>
+                        <li><strong>Reframe:</strong> deliberate change to an anchored concept, logged for consistency tracking.</li>
+                    </ul>
+                `,
+                speech: 'Glossary. Arc of Abstraction: the mental continuum from concrete or particular to abstract or general. Up-shift and Down-shift: moves along the arc, north and south. Analogue and Opposite: lateral moves preserving or inverting role, east and west. Anchor: your chosen seed concept for a letter. Compound mapping: a single letter carrying a composed phrase to satisfy multiple relations, for example Chaotic example. Reframe: deliberate change to an anchored concept, logged for consistency tracking.'
+            }
+        ];
+
+        const SANDBOX_TRANSFORMS = {
+            N: {
+                forward: (value) => `Up-shift(${value})`,
+                reverse: (value) => `Down-shift(${value})`
+            },
+            S: {
+                forward: (value) => `Down-shift(${value})`,
+                reverse: (value) => `Up-shift(${value})`
+            },
+            E: {
+                forward: (value) => `Analogue(${value})`,
+                reverse: (value) => `Analogue(${value})`
+            },
+            W: {
+                forward: (value) => `Opposite(${value})`,
+                reverse: (value) => `Opposite(${value})`
+            }
+        };
 
         function loadNumTrials() {
             const v = parseInt(localStorage.getItem(NUM_TRIALS_KEY) || '20', 10);
@@ -3197,6 +3605,532 @@
             }
         }
 
+        class InstructionsManager {
+            constructor(engine) {
+                this.engine = engine;
+                this.voice = engine.voice;
+                this.sections = TUTORIAL_SECTIONS;
+                this.dialog = document.getElementById('dlgInstructions');
+                this.openButton = document.getElementById('btnInstructions');
+                this.closeButton = document.getElementById('instClose');
+                this.nav = document.getElementById('instTabs');
+                this.tabButtons = Array.from(this.nav.querySelectorAll('button'));
+                this.content = document.getElementById('instContent');
+                this.prevButton = document.getElementById('instPrev');
+                this.nextButton = document.getElementById('instNext');
+                this.readAloudCheckbox = document.getElementById('instReadAloud');
+                this.currentIndex = 0;
+                this.dialogOpen = false;
+                this.previousFocus = null;
+                this.visited = new Set();
+                this.completed = false;
+                this.readAloud = false;
+                this.pendingSpeechToken = null;
+                this.boundKeydown = (event) => this.handleKeydown(event);
+                this.boundFocusIn = (event) => this.enforceFocus(event);
+                this.nav.setAttribute('role', 'tablist');
+                this.tabButtons.forEach(btn => {
+                    btn.setAttribute('role', 'tab');
+                    btn.setAttribute('aria-selected', btn.classList.contains('active') ? 'true' : 'false');
+                    btn.setAttribute('tabindex', btn.classList.contains('active') ? '0' : '-1');
+                });
+                this.sandbox = {
+                    premise: null,
+                    mapping: {},
+                    journal: []
+                };
+                this.sandboxElements = null;
+            }
+
+            initialize() {
+                this.loadState();
+                this.attachEvents();
+                this.renderCurrentSection();
+                this.updateCompletionState();
+            }
+
+            loadState() {
+                const storedSection = localStorage.getItem('instSection');
+                const storedIndex = this.sections.findIndex(section => section.id === storedSection);
+                if (storedIndex >= 0) {
+                    this.currentIndex = storedIndex;
+                }
+
+                const visitedRaw = localStorage.getItem('instVisited');
+                if (visitedRaw) {
+                    try {
+                        const parsed = JSON.parse(visitedRaw);
+                        if (Array.isArray(parsed)) {
+                            parsed.forEach(id => this.visited.add(id));
+                        }
+                    } catch (err) {
+                        console.warn('Failed to parse tutorial visited state', err);
+                    }
+                }
+
+                const completed = localStorage.getItem('instCompleted');
+                this.completed = completed === 'true';
+
+                const readAloud = localStorage.getItem('instReadAloud');
+                this.readAloud = readAloud === 'true';
+                this.readAloudCheckbox.checked = this.readAloud;
+
+                const journalRaw = localStorage.getItem('instPracticeJournal');
+                if (journalRaw) {
+                    try {
+                        const parsed = JSON.parse(journalRaw);
+                        if (Array.isArray(parsed)) {
+                            this.sandbox.journal = parsed;
+                        }
+                    } catch (err) {
+                        console.warn('Failed to parse sandbox journal', err);
+                    }
+                }
+            }
+
+            attachEvents() {
+                this.openButton.addEventListener('click', () => this.openDialog());
+                this.closeButton.addEventListener('click', () => this.closeDialog());
+
+                this.tabButtons.forEach((button, index) => {
+                    button.addEventListener('click', () => {
+                        this.currentIndex = index;
+                        this.renderCurrentSection();
+                        if (this.dialogOpen && this.readAloud) {
+                            this.queueSpeech();
+                        }
+                    });
+                });
+
+                this.prevButton.addEventListener('click', () => {
+                    if (this.currentIndex > 0) {
+                        this.currentIndex -= 1;
+                        this.renderCurrentSection();
+                        if (this.dialogOpen && this.readAloud) {
+                            this.queueSpeech();
+                        }
+                    }
+                });
+
+                this.nextButton.addEventListener('click', () => {
+                    if (this.currentIndex < this.sections.length - 1) {
+                        this.currentIndex += 1;
+                        this.renderCurrentSection();
+                        if (this.dialogOpen && this.readAloud) {
+                            this.queueSpeech();
+                        }
+                    }
+                });
+
+                this.readAloudCheckbox.addEventListener('change', (event) => {
+                    this.readAloud = event.target.checked;
+                    localStorage.setItem('instReadAloud', this.readAloud ? 'true' : 'false');
+                    if (this.dialogOpen && this.readAloud) {
+                        this.queueSpeech(true);
+                    } else {
+                        this.cancelSpeech();
+                    }
+                });
+            }
+
+            openDialog() {
+                if (this.dialogOpen) return;
+                this.dialogOpen = true;
+                this.previousFocus = document.activeElement;
+                this.dialog.hidden = false;
+                document.body.classList.add('dialog-open');
+                this.content.scrollTop = 0;
+                this.markVisited(this.sections[this.currentIndex].id);
+                this.focusInitialElement();
+                document.addEventListener('keydown', this.boundKeydown, true);
+                document.addEventListener('focusin', this.boundFocusIn, true);
+                if (this.readAloud) {
+                    this.queueSpeech(true);
+                }
+            }
+
+            closeDialog() {
+                if (!this.dialogOpen) return;
+                this.dialogOpen = false;
+                this.dialog.hidden = true;
+                document.body.classList.remove('dialog-open');
+                document.removeEventListener('keydown', this.boundKeydown, true);
+                document.removeEventListener('focusin', this.boundFocusIn, true);
+                this.cancelSpeech();
+                if (this.previousFocus && typeof this.previousFocus.focus === 'function') {
+                    this.previousFocus.focus();
+                } else {
+                    this.openButton.focus();
+                }
+            }
+
+            handleKeydown(event) {
+                if (!this.dialogOpen) return;
+                if (event.key === 'Escape') {
+                    event.preventDefault();
+                    this.closeDialog();
+                    return;
+                }
+                if (event.key === 'Tab') {
+                    this.trapFocus(event);
+                }
+            }
+
+            enforceFocus(event) {
+                if (!this.dialogOpen) return;
+                if (!this.dialog.contains(event.target)) {
+                    const focusable = this.getFocusableElements();
+                    if (focusable.length > 0) {
+                        focusable[0].focus();
+                    } else {
+                        this.content.focus();
+                    }
+                }
+            }
+
+            trapFocus(event) {
+                const focusable = this.getFocusableElements();
+                if (focusable.length === 0) {
+                    event.preventDefault();
+                    this.content.focus();
+                    return;
+                }
+                const first = focusable[0];
+                const last = focusable[focusable.length - 1];
+                const active = document.activeElement;
+
+                if (event.shiftKey) {
+                    if (active === first || !this.dialog.contains(active)) {
+                        event.preventDefault();
+                        last.focus();
+                    }
+                } else {
+                    if (active === last) {
+                        event.preventDefault();
+                        first.focus();
+                    }
+                }
+            }
+
+            getFocusableElements() {
+                const selectors = ['button', '[href]', 'input', 'select', 'textarea', '[tabindex]:not([tabindex="-1"])'];
+                return Array.from(this.dialog.querySelectorAll(selectors.join(',')))
+                    .filter(el => !el.hasAttribute('disabled') && el.tabIndex !== -1 && this.dialog.contains(el));
+            }
+
+            focusInitialElement() {
+                const focusable = this.getFocusableElements();
+                if (focusable.length > 0) {
+                    focusable[0].focus();
+                } else {
+                    this.content.focus();
+                }
+            }
+
+            renderCurrentSection() {
+                const section = this.sections[this.currentIndex];
+                if (!section) return;
+                this.tabButtons.forEach((button, idx) => {
+                    const isActive = idx === this.currentIndex;
+                    button.classList.toggle('active', isActive);
+                    if (this.visited.has(this.sections[idx].id)) {
+                        button.classList.add('visited');
+                    }
+                    button.setAttribute('aria-selected', isActive ? 'true' : 'false');
+                    button.setAttribute('tabindex', isActive ? '0' : '-1');
+                });
+                this.content.innerHTML = section.html;
+                this.content.scrollTop = 0;
+                localStorage.setItem('instSection', section.id);
+                this.markVisited(section.id);
+                this.updateNavButtons();
+                if (section.id === 'practice') {
+                    this.setupSandboxUI();
+                } else {
+                    this.sandboxElements = null;
+                }
+                if (this.dialogOpen && this.readAloud) {
+                    this.queueSpeech();
+                }
+            }
+
+            updateNavButtons() {
+                this.prevButton.disabled = this.currentIndex === 0;
+                this.nextButton.disabled = this.currentIndex === this.sections.length - 1;
+            }
+
+            markVisited(id) {
+                if (!this.visited.has(id)) {
+                    this.visited.add(id);
+                    localStorage.setItem('instVisited', JSON.stringify(Array.from(this.visited)));
+                }
+                if (this.visited.size === this.sections.length) {
+                    this.completed = true;
+                    localStorage.setItem('instCompleted', 'true');
+                }
+                this.updateCompletionState();
+            }
+
+            updateCompletionState() {
+                this.openButton.classList.toggle('completed', this.completed);
+            }
+
+            async queueSpeech(force = false) {
+                if (!this.readAloud || !this.dialogOpen) return;
+                if (!this.voice || !this.voice.voiceReady) return;
+                const section = this.sections[this.currentIndex];
+                if (!section || !section.speech) return;
+                const token = Symbol('instSpeech');
+                this.pendingSpeechToken = token;
+                if (force) {
+                    await this.voice.cancelAndWait();
+                } else {
+                    await this.voice.cancelAndWait();
+                }
+                await new Promise(resolve => setTimeout(resolve, 100));
+                if (!this.dialogOpen || !this.readAloud || this.pendingSpeechToken !== token) {
+                    return;
+                }
+                await this.voice.speak(section.speech, this.engine.sessionToken);
+            }
+
+            cancelSpeech() {
+                this.pendingSpeechToken = null;
+                if (this.voice && typeof this.voice.cancelAndWait === 'function') {
+                    this.voice.cancelAndWait();
+                }
+            }
+
+            setupSandboxUI() {
+                const panel = document.createElement('div');
+                panel.className = 'sandbox-panel';
+
+                const workspaceTitle = document.createElement('h4');
+                workspaceTitle.textContent = 'Practice Workspace';
+                panel.appendChild(workspaceTitle);
+
+                const controls = document.createElement('div');
+                controls.className = 'sandbox-controls';
+
+                const loadBtn = this.createSandboxButton('Load current premise', () => this.loadCurrentPremise());
+                const spawnBtn = this.createSandboxButton('Spawn practice premise', () => this.spawnPracticePremise());
+                const applyBtn = this.createSandboxButton('Apply Relation Operations', () => this.applySandboxOperations());
+                const commitBtn = this.createSandboxButton('Commit to Journal', () => this.commitSandboxJournal());
+
+                controls.append(loadBtn, spawnBtn, applyBtn, commitBtn);
+                panel.appendChild(controls);
+
+                const status = document.createElement('div');
+                status.className = 'hint';
+                panel.appendChild(status);
+
+                const atoms = document.createElement('div');
+                atoms.className = 'sandbox-atom-list';
+                panel.appendChild(atoms);
+
+                const grid = document.createElement('div');
+                grid.className = 'sandbox-letter-grid';
+                panel.appendChild(grid);
+
+                const journalTitle = document.createElement('h4');
+                journalTitle.textContent = 'Journal';
+                panel.appendChild(journalTitle);
+
+                const journal = document.createElement('div');
+                journal.className = 'sandbox-journal';
+                panel.appendChild(journal);
+
+                this.content.appendChild(panel);
+
+                this.sandboxElements = {
+                    status,
+                    atoms,
+                    grid,
+                    journal
+                };
+
+                this.renderSandboxPremise();
+                this.renderSandboxInputs();
+                this.renderSandboxJournal();
+                this.updateSandboxStatus('Load the latest premise or spawn a fresh training premise to begin.');
+            }
+
+            createSandboxButton(label, handler) {
+                const btn = document.createElement('button');
+                btn.type = 'button';
+                btn.className = 'secondary';
+                btn.textContent = label;
+                btn.addEventListener('click', handler);
+                return btn;
+            }
+
+            loadCurrentPremise() {
+                const current = this.engine.currentPremises && this.engine.currentPremises.length > 0
+                    ? this.engine.currentPremises[this.engine.currentPremises.length - 1]
+                    : null;
+                if (!current) {
+                    this.updateSandboxStatus('No live premise available yet. Start a session or spawn practice.');
+                    return;
+                }
+                this.sandbox.premise = {
+                    atoms: current.atoms.map(atom => ({ axis: atom.axis, head: atom.head, tail: atom.tail }))
+                };
+                this.sandbox.mapping = {};
+                this.renderSandboxPremise();
+                this.renderSandboxInputs();
+                this.updateSandboxStatus('Loaded the latest live premise into the sandbox.');
+            }
+
+            spawnPracticePremise() {
+                const practice = this.generatePracticePremise();
+                this.sandbox.premise = practice;
+                this.sandbox.mapping = {};
+                this.renderSandboxPremise();
+                this.renderSandboxInputs();
+                this.updateSandboxStatus('Spawned a fresh training premise.');
+            }
+
+            generatePracticePremise() {
+                const k = Math.max(2, Math.min(4, this.engine ? this.engine.k : 3));
+                const letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'.split('');
+                const usedPairs = new Set();
+                const atoms = [];
+                for (let i = 0; i < k; i++) {
+                    let head = letters[Math.floor(Math.random() * letters.length)];
+                    let tail = letters[Math.floor(Math.random() * letters.length)];
+                    let attempts = 0;
+                    while ((head === tail || usedPairs.has(`${head}-${tail}`)) && attempts < 40) {
+                        head = letters[Math.floor(Math.random() * letters.length)];
+                        tail = letters[Math.floor(Math.random() * letters.length)];
+                        attempts += 1;
+                    }
+                    usedPairs.add(`${head}-${tail}`);
+                    const axis = MATCH_AXES[Math.floor(Math.random() * MATCH_AXES.length)];
+                    atoms.push({ axis, head, tail });
+                }
+                return { atoms };
+            }
+
+            applySandboxOperations() {
+                if (!this.sandbox.premise) {
+                    this.updateSandboxStatus('Load or spawn a premise before applying operations.');
+                    return;
+                }
+                let changed = false;
+                const mapping = this.sandbox.mapping;
+                this.sandbox.premise.atoms.forEach(atom => {
+                    const headKey = atom.head;
+                    const tailKey = atom.tail;
+                    const headValue = (mapping[headKey] || '').trim();
+                    const tailValue = (mapping[tailKey] || '').trim();
+                    const transform = SANDBOX_TRANSFORMS[atom.axis];
+                    if (!transform) return;
+                    if (tailValue && !headValue) {
+                        mapping[headKey] = transform.forward(tailValue);
+                        changed = true;
+                    } else if (headValue && !tailValue) {
+                        mapping[tailKey] = transform.reverse(headValue);
+                        changed = true;
+                    }
+                });
+                this.renderSandboxInputs();
+                this.updateSandboxStatus(changed ? 'Applied relation operations. Tweak any concept as needed.' : 'No changes applied. Anchor at least one letter first.');
+            }
+
+            commitSandboxJournal() {
+                if (!this.sandbox.premise) {
+                    this.updateSandboxStatus('Load or spawn a premise before committing to the journal.');
+                    return;
+                }
+                const entries = Object.entries(this.sandbox.mapping)
+                    .map(([letter, value]) => [letter, value ? value.trim() : ''])
+                    .filter(([, value]) => value.length > 0)
+                    .sort((a, b) => a[0].localeCompare(b[0]));
+                if (entries.length === 0) {
+                    this.updateSandboxStatus('Add at least one mapped concept before committing.');
+                    return;
+                }
+                const record = {
+                    timestamp: new Date().toISOString(),
+                    premise: this.sandbox.premise.atoms,
+                    mapping: entries
+                };
+                this.sandbox.journal.unshift(record);
+                this.sandbox.journal = this.sandbox.journal.slice(0, 20);
+                localStorage.setItem('instPracticeJournal', JSON.stringify(this.sandbox.journal));
+                this.renderSandboxJournal();
+                this.updateSandboxStatus('Mapping committed to journal.');
+            }
+
+            renderSandboxPremise() {
+                if (!this.sandboxElements) return;
+                const atoms = this.sandbox.premise ? this.sandbox.premise.atoms : [];
+                if (!atoms || atoms.length === 0) {
+                    this.sandboxElements.atoms.textContent = 'No practice premise loaded yet.';
+                } else {
+                    this.sandboxElements.atoms.textContent = atoms
+                        .map(atom => `${atom.head} is ${RELATION_WORDS[atom.axis]} ${atom.tail}`)
+                        .join('; ');
+                }
+            }
+
+            renderSandboxInputs() {
+                if (!this.sandboxElements) return;
+                const grid = this.sandboxElements.grid;
+                grid.innerHTML = '';
+                if (!this.sandbox.premise) return;
+                const letters = new Set();
+                this.sandbox.premise.atoms.forEach(atom => {
+                    letters.add(atom.head);
+                    letters.add(atom.tail);
+                });
+                Array.from(letters).sort().forEach(letter => {
+                    const cell = document.createElement('div');
+                    cell.className = 'sandbox-letter';
+                    const label = document.createElement('label');
+                    label.textContent = `${letter} concept`;
+                    const input = document.createElement('input');
+                    input.type = 'text';
+                    input.value = this.sandbox.mapping[letter] || '';
+                    input.addEventListener('input', (event) => {
+                        this.sandbox.mapping[letter] = event.target.value;
+                    });
+                    cell.append(label, input);
+                    grid.appendChild(cell);
+                });
+            }
+
+            renderSandboxJournal() {
+                if (!this.sandboxElements) return;
+                const journal = this.sandboxElements.journal;
+                journal.innerHTML = '';
+                if (this.sandbox.journal.length === 0) {
+                    const empty = document.createElement('p');
+                    empty.className = 'hint';
+                    empty.textContent = 'Your journal entries will appear here.';
+                    journal.appendChild(empty);
+                    return;
+                }
+                this.sandbox.journal.forEach(entry => {
+                    const item = document.createElement('div');
+                    item.className = 'sandbox-journal-entry';
+                    const timestamp = document.createElement('div');
+                    timestamp.innerHTML = `<strong>${new Date(entry.timestamp).toLocaleString()}</strong>`;
+                    const premise = document.createElement('div');
+                    premise.textContent = `Premise: ${entry.premise.map(atom => `${atom.head} is ${RELATION_WORDS[atom.axis]} ${atom.tail}`).join('; ')}`;
+                    const mapping = document.createElement('div');
+                    mapping.innerHTML = entry.mapping.map(([letter, value]) => `<code>${letter}</code>: ${value}`).join('; ');
+                    item.append(timestamp, premise, mapping);
+                    journal.appendChild(item);
+                });
+            }
+
+            updateSandboxStatus(message) {
+                if (!this.sandboxElements) return;
+                this.sandboxElements.status.textContent = message;
+            }
+        }
+
         class TestHarness {
             constructor() {
                 this.seedManager = new SeedManager();
@@ -3309,7 +4243,14 @@
         }
 
         const engine = new GameEngine();
-        engine.initialize();
+        const instructions = new InstructionsManager(engine);
+        instructions.initialize();
+        engine.initialize().then(() => {
+            instructions.updateCompletionState();
+            if (instructions.dialogOpen && instructions.readAloud) {
+                instructions.queueSpeech(true);
+            }
+        });
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add an Instructions control and modal that matches the Imagi-World branding and accessibility requirements
- load the structured tutorial copy with optional read-aloud playback and section tracking
- implement a sandbox practice workspace for analogical mapping with journal persistence

## Testing
- not run (web app change only)


------
https://chatgpt.com/codex/tasks/task_e_68e1cd80365c832db0eff8994f8d577f