### PR TITLE
Implement single-flight speech gate for premise audio

### DIFF
--- a/index.html
+++ b/index.html
@@ -1630,6 +1630,38 @@
             );
         }
 
+        const SpeechGate = {
+            trialSpeakId: 0,
+            inFlight: false,
+            explicitRepeatPhase: 0,
+            flightToken: null
+        };
+
+        function resetSpeechGateForTrial() {
+            SpeechGate.trialSpeakId += 1;
+            SpeechGate.inFlight = false;
+            SpeechGate.flightToken = null;
+        }
+
+        function noteExplicitRepeat() {
+            SpeechGate.explicitRepeatPhase += 1;
+        }
+
+        const TTSMon = { starts: 0, ends: 0 };
+
+        function instrumentUtterance(utterance) {
+            if (!utterance || typeof utterance.addEventListener !== 'function') {
+                return;
+            }
+            utterance.addEventListener('start', () => { TTSMon.starts += 1; });
+            utterance.addEventListener('end', () => { TTSMon.ends += 1; });
+        }
+
+        if (typeof window !== 'undefined') {
+            window.SpeechGate = SpeechGate;
+            window.TTSMon = TTSMon;
+        }
+
         const Timer = (() => {
             let id = 0;
             const live = new Map();
@@ -3740,81 +3772,52 @@
                 }
 
                 return new Promise(resolve => {
-                    let attempt = 0;
-                    const maxAttempts = 2;
-                    const speakAttempt = () => {
-                        if (guardToken && guardToken !== this.sessionToken) {
-                            resolve({ fallback: attempt > 1, attempts: attempt });
-                            return;
-                        }
+                    if (guardToken && guardToken !== this.sessionToken) {
+                        resolve({ fallback: false, attempts: 0 });
+                        return;
+                    }
 
-                        attempt += 1;
-                        const utterance = new SpeechSynthesisUtterance(text);
-                        const voice = this.getLockedVoice();
-                        if (voice) {
-                            utterance.voice = voice;
-                            utterance.lang = voice.lang;
-                        }
-                        utterance.pitch = this.pitch;
-                        utterance.rate = this.rate;
-                        utterance.volume = this.volume;
+                    const utterance = new SpeechSynthesisUtterance(text);
+                    const voice = this.getLockedVoice();
+                    if (voice) {
+                        utterance.voice = voice;
+                        utterance.lang = voice.lang;
+                    }
+                    utterance.pitch = this.pitch;
+                    utterance.rate = this.rate;
+                    utterance.volume = this.volume;
 
-                        let settled = false;
-                        let fallbackTimer = null;
-
-                        const cleanup = () => {
-                            if (fallbackTimer) {
-                                clearTimeout(fallbackTimer);
-                                fallbackTimer = null;
-                            }
-                        };
-
-                        const finish = () => {
-                            if (settled) return;
-                            settled = true;
-                            cleanup();
-                            resolve({ fallback: attempt > 1, attempts: attempt });
-                        };
-
-                        const retry = () => {
-                            if (settled) return;
-                            cleanup();
-                            if (attempt >= maxAttempts) {
-                                settled = true;
-                                resolve({ fallback: attempt > 1, attempts: attempt });
-                                return;
-                            }
-                            try {
-                                this.synth.cancel();
-                            } catch (err) {
-                                console.warn('speechSynthesis.cancel retry failed', err);
-                            }
-                            setTimeout(() => speakAttempt(), 120);
-                        };
-
-                        const estimate = estimateUtteranceMs(text, this.rate) + 400;
-                        fallbackTimer = setTimeout(() => retry(), estimate);
-
-                        utterance.onend = () => finish();
-                        utterance.onerror = () => retry();
-
-                        setTimeout(() => {
-                            if (settled) return;
-                            try {
-                                this.synth.resume();
-                            } catch (err) {
-                                console.warn('speechSynthesis.resume failed', err);
-                            }
-                            try {
-                                this.synth.speak(utterance);
-                            } catch (err) {
-                                console.warn('speechSynthesis.speak failed', err);
-                                retry();
-                            }
-                        }, 120);
+                    let settled = false;
+                    const finish = (fallback) => {
+                        if (settled) return;
+                        settled = true;
+                        clearTimeout(fallbackTimer);
+                        resolve({ fallback, attempts: 1 });
                     };
 
-                    speakAttempt();
+                    const fallbackTimer = setTimeout(() => finish(true), estimateUtteranceMs(text, this.rate) + 400);
+
+                    utterance.onend = () => finish(false);
+                    utterance.onerror = () => finish(true);
+
+                    setTimeout(() => {
+                        if (settled) return;
+                        if (guardToken && guardToken !== this.sessionToken) {
+                            finish(true);
+                            return;
+                        }
+                        try {
+                            this.synth.resume();
+                        } catch (err) {
+                            console.warn('speechSynthesis.resume failed', err);
+                        }
+                        try {
+                            this.synth.speak(utterance);
+                        } catch (err) {
+                            console.warn('speechSynthesis.speak failed', err);
+                            finish(true);
+                        }
+                    }, 120);
                 });
             }
 
@@ -3919,6 +3922,11 @@
             }
 
             attachUI() {
+                if (window._imagiHandlersBound) {
+                    return;
+                }
+                window._imagiHandlersBound = true;
+
                 const lockSeedToggle = document.getElementById('lock-seed-toggle');
                 if (lockSeedToggle) {
                     lockSeedToggle.checked = this.lockSeed;
@@ -4271,6 +4279,7 @@
 
             async executeTrial(sess, trialToken, signal) {
                 if (!valid(sess, trialToken)) return;
+                resetSpeechGateForTrial();
                 const currentIndex = sess.trialIndex;
                 this.session.trialIndex = currentIndex;
                 this.updateUI();
@@ -4538,6 +4547,8 @@
             }
             clearAllEngineTimers();
             cancelSpeechImmediately();
+            SpeechGate.inFlight = false;
+            SpeechGate.flightToken = null;
             engine.finalizeSession(session, true);
             window.__imagiActiveResponse = null;
             window.forceCurrentTrialTimeout = null;
@@ -4589,33 +4600,104 @@
         }
 
         async function speakPremiseSafe(sess, premise, trialToken, signal) {
-            if (!valid(sess, trialToken)) return { fallback: false };
-            cancelSpeechImmediately();
-            const text = formatPremiseForSpeech(premise);
-            window.currentPremiseText = text;
-            let settled = false;
+            if (!valid(sess, trialToken)) {
+                return { fallback: false, attempts: 0 };
+            }
 
             return new Promise((resolve) => {
-                const onAbort = () => {
+                const mySpeakId = SpeechGate.trialSpeakId;
+                const myRepeatPhase = SpeechGate.explicitRepeatPhase;
+
+                if (SpeechGate.inFlight) {
+                    resolve({ fallback: false, attempts: 0 });
+                    return;
+                }
+
+                const flightToken = Symbol('speech-flight');
+                SpeechGate.inFlight = true;
+                SpeechGate.flightToken = flightToken;
+
+                try {
+                    window.speechSynthesis?.cancel();
+                } catch (err) {
+                    console.warn('speechSynthesis.cancel before speak failed', err);
+                }
+
+                const text = formatPremiseForSpeech(premise);
+                window.currentPremiseText = text;
+                const utterance = new SpeechSynthesisUtterance(text);
+                const lockedVoice = engine?.voice?.getLockedVoice?.();
+                if (lockedVoice) {
+                    utterance.voice = lockedVoice;
+                    utterance.lang = lockedVoice.lang;
+                }
+                const pitch = engine?.voice?.pitch ?? 1.2;
+                const rate = engine?.voice?.rate ?? 0.9;
+                const volume = engine?.voice?.volume ?? 1.0;
+                utterance.pitch = pitch;
+                utterance.rate = rate;
+                utterance.volume = volume;
+
+                instrumentUtterance(utterance);
+
+                let settled = false;
+
+                const finish = (fallback) => {
                     if (settled) return;
                     settled = true;
-                    resolve({ fallback: false });
+                    if (SpeechGate.flightToken === flightToken) {
+                        SpeechGate.inFlight = false;
+                        SpeechGate.flightToken = null;
+                    }
+                    clearTimeout(fallbackTimer);
+                    signal.removeEventListener('abort', onAbort);
+                    resolve({ fallback, attempts: 1 });
                 };
 
+                const onAbort = () => finish(false);
                 signal.addEventListener('abort', onAbort, { once: true });
 
-                engine.voice.speak(text, engine.voice.sessionToken).then((meta) => {
+                const fallbackTimer = setTimeout(() => {
+                    if (SpeechGate.trialSpeakId !== mySpeakId) {
+                        finish(true);
+                        return;
+                    }
+                    if (SpeechGate.explicitRepeatPhase !== myRepeatPhase) {
+                        finish(false);
+                        return;
+                    }
+                    finish(true);
+                }, estimateUtteranceMs(text, rate) + 400);
+
+                utterance.onend = () => finish(false);
+                utterance.onerror = () => finish(true);
+
+                setTimeout(() => {
                     if (settled) return;
-                    settled = true;
-                    signal.removeEventListener('abort', onAbort);
-                    resolve(meta);
-                }).catch((err) => {
-                    console.warn('speakPremiseSafe fallback error', err);
-                    if (settled) return;
-                    settled = true;
-                    signal.removeEventListener('abort', onAbort);
-                    resolve({ fallback: true });
-                });
+                    if (!valid(sess, trialToken) || signal.aborted) {
+                        finish(true);
+                        return;
+                    }
+                    if (SpeechGate.trialSpeakId !== mySpeakId) {
+                        finish(true);
+                        return;
+                    }
+                    if (SpeechGate.explicitRepeatPhase !== myRepeatPhase) {
+                        finish(false);
+                        return;
+                    }
+                    try {
+                        window.speechSynthesis?.resume();
+                    } catch (err) {
+                        console.warn('speechSynthesis.resume failed', err);
+                    }
+                    try {
+                        window.speechSynthesis?.speak(utterance);
+                    } catch (err) {
+                        console.warn('speechSynthesis.speak failed', err);
+                        finish(true);
+                    }
+                }, 100);
             });
         }
 
@@ -4714,9 +4796,12 @@
             if (!session) return;
             const premise = engine.activePremise || engine.currentPremises[Math.max(0, session.trialIndex - 1)];
             if (!premise) return;
+            noteExplicitRepeat();
             cancelSpeechImmediately();
             setTimeout(() => {
                 if (!session || session.abort.signal.aborted) return;
+                SpeechGate.inFlight = false;
+                SpeechGate.flightToken = null;
                 speakPremiseSafe(session, premise, session.trialToken, session.abort.signal);
             }, 120);
         }


### PR DESCRIPTION
## Summary
- add a session-level SpeechGate with TTS instrumentation to guarantee a single utterance per trial
- rework the voice speaking pipeline to drop automatic retries and rely on guarded single-flight playback
- hook repeat/stop handling into the gate while preventing duplicate UI bindings

## Testing
- not run (web assets)


------
https://chatgpt.com/codex/tasks/task_e_68e21a5b7970832dba3e3a8fba8a4bce